### PR TITLE
Add connector publishing CI for voodoo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,162 @@
+version: 2.1
+
+orbs:
+  aws-cli: circleci/aws-cli@1.3.0
+  aws-ecr: circleci/aws-ecr@8.1.2
+  github-ops: voodooteam/github-ops@2
+  docker: circleci/docker@2
+
+jobs:
+  dependencies_facebook:
+    working_directory: ~/airbyte/airbyte-integrations/connectors/source-facebook-marketing
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+
+  dependencies_applovin:
+    working_directory: ~/airbyte/airbyte-integrations/connectors/source-applovin
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+
+  dependencies_tiktok:
+    working_directory: ~/airbyte/airbyte-integrations/connectors/source-tiktok-marketing
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+
+  dependencies_googleads:
+    working_directory: ~/airbyte/airbyte-integrations/connectors/source-google-ads
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+
+  dependencies_ironsource:
+    working_directory: ~/airbyte/airbyte-integrations/connectors/source-ironsource
+    machine:
+      image: ubuntu-2004:202201-02
+    steps:
+      - checkout
+
+workflows:
+  version: 2
+  deployment:
+    jobs:
+      - dependencies_facebook:
+          context:
+            - github-voodoo-bender
+            - VOODOO_INFRA_TOOLS
+
+      - dependencies_applovin:
+          context:
+            - github-voodoo-bender
+            - VOODOO_INFRA_TOOLS
+
+      - dependencies_tiktok:
+          context:
+            - github-voodoo-bender
+            - VOODOO_INFRA_TOOLS
+
+      - dependencies_googleads:
+          context:
+            - github-voodoo-bender
+            - VOODOO_INFRA_TOOLS
+
+      - dependencies_ironsource:
+          context:
+            - github-voodoo-bender
+            - VOODOO_INFRA_TOOLS
+
+      - aws-ecr/build-and-push-image:
+          path: airbyte-integrations/connectors/source-facebook-marketing/
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          context: VOODOO_INFRA_TOOLS
+          create-repo: false
+          no-output-timeout: 20m
+          repo: "data-core/vgp-data-airbyte-facebook"
+          tag: << pipeline.git.revision >>
+          skip-when-tags-exist: true
+          requires:
+            - dependencies_facebook
+          filters:
+            branches:
+              only:
+                - voodoo_master
+
+      - aws-ecr/build-and-push-image:
+          path: airbyte-integrations/connectors/source-applovin/
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          context: VOODOO_INFRA_TOOLS
+          create-repo: false
+          no-output-timeout: 20m
+          repo: "data-core/vgp-data-airbyte-applovin"
+          tag: << pipeline.git.revision >>
+          skip-when-tags-exist: true
+          requires:
+            - dependencies_applovin
+          filters:
+            branches:
+              only:
+                - voodoo_master
+
+      - aws-ecr/build-and-push-image:
+          path: airbyte-integrations/connectors/source-tiktok-marketing/
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          context: VOODOO_INFRA_TOOLS
+          create-repo: false
+          no-output-timeout: 20m
+          repo: "data-core/vgp-data-airbyte-tiktok"
+          tag: << pipeline.git.revision >>
+          skip-when-tags-exist: true
+          requires:
+            - dependencies_tiktok
+          filters:
+            branches:
+              only:
+                - voodoo_master
+
+      - aws-ecr/build-and-push-image:
+          path: airbyte-integrations/connectors/source-google-ads/
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          context: VOODOO_INFRA_TOOLS
+          create-repo: false
+          no-output-timeout: 20m
+          repo: "data-core/vgp-data-airbyte-google-ads"
+          tag: << pipeline.git.revision >>
+          skip-when-tags-exist: true
+          requires:
+            - dependencies_googleads
+          filters:
+            branches:
+              only:
+                - voodoo_master
+
+      - aws-ecr/build-and-push-image:
+          path: airbyte-integrations/connectors/source-ironsource/
+          executor:
+            name: aws-ecr/default
+            use-docker-layer-caching: true
+          context: VOODOO_INFRA_TOOLS
+          create-repo: false
+          no-output-timeout: 20m
+          repo: "data-core/vgp-data-airbyte-ironsource"
+          tag: << pipeline.git.revision >>
+          skip-when-tags-exist: true
+          requires:
+            - dependencies_ironsource
+          filters:
+            branches:
+              only:
+                - voodoo_master


### PR DESCRIPTION
<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- [ ] Pull Request description explains what problem it is solving
- [ ] Code change is unit tested
- [ ] Build and my-py check pass
- [ ] Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- [ ] PR is reviewed and approved
      
After merging:
- [ ] [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- [ ] Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
