### PR TITLE
Improve google ads performance by only aggregating the last row per entity-primary key

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog_voodoo.json
+++ b/airbyte-integrations/connectors/source-google-ads/integration_tests/configured_catalog_voodoo.json
@@ -1,0 +1,98 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "customer",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
+        "source_defined_primary_key": [["customer.id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"],
+      "primary_key": [["customer.id"]]
+    },
+    {
+      "stream": {
+        "name": "campaign",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
+        "source_defined_primary_key": [
+          ["campaign.id"]
+        ]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"],
+      "primary_key": [
+        ["campaign.id"]
+      ]
+    },
+    {
+      "stream": {
+        "name": "ad_group",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
+        "source_defined_primary_key": [["ad_group.id"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"],
+      "primary_key": [["ad_group.id"]]
+    },
+    {
+      "stream": {
+        "name": "ad_group_ad",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "source_defined_primary_key": [
+          ["ad_group.id"],
+          ["ad_group_ad.ad.id"]
+        ],
+        "default_cursor_field": ["segments.date"]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"],
+      "primary_key": [["ad_group.id"], ["ad_group_ad.ad.id"]]
+    },
+    {
+      "stream": {
+        "name": "campaign_budget",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_cursor": true,
+        "default_cursor_field": ["segments.date"],
+        "source_defined_primary_key": [
+          ["customer.id"],
+          ["campaign_budget.id"]
+        ]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "cursor_field": ["segments.date"],
+      "primary_key": [
+        ["customer.id"],
+        ["campaign_budget.id"]
+      ]
+    },
+    {
+      "stream": {
+        "name": "campaign_criterion",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh", "incremental"],
+        "source_defined_primary_key": [["campaign_criterion.resource_name"]]
+      },
+      "sync_mode": "incremental",
+      "destination_sync_mode": "overwrite",
+      "primary_key": [["campaign_criterion.resource_name"]]
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign.json
@@ -317,12 +317,6 @@
     "segments.date": {
       "type": ["null", "string"],
       "format": "date"
-    },
-    "segments.hour": {
-      "type": ["null", "integer"]
-    },
-    "segments.ad_network_type": {
-      "type": ["null", "string"]
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign_budget.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/schemas/campaign_budget.json
@@ -66,12 +66,6 @@
       "type": ["null", "string"],
       "format": "date"
     },
-    "segments.budget_campaign_association_status.campaign": {
-      "type": ["null", "string"]
-    },
-    "segments.budget_campaign_association_status.status": {
-      "type": ["null", "string"]
-    },
     "metrics.all_conversions": {
       "type": ["null", "number"]
     },

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/streams.py
@@ -40,11 +40,11 @@ class GoogleAdsStream(Stream, ABC):
         primary_key = ' '.join(self.primary_key)
         for result in response:
             record = self.google_ads_client.parse_single_result(self.get_json_schema(), result)
-            campaign_id = record.get(primary_key)
-            if (latest_records.get(campaign_id) is None
+            id = record.get(primary_key)
+            if (latest_records.get(id) is None
                     or record.get("segments_date") is None
-                    or pendulum.parse(latest_records[campaign_id]["segments.date"]) < pendulum.parse(record.get("segments.date"))):
-                latest_records[campaign_id] = record
+                    or pendulum.parse(latest_records[id]["segments.date"]) < pendulum.parse(record.get("segments.date"))):
+                latest_records[id] = record
 
         yield from latest_records.values()
 

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/utils.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/utils.py
@@ -5,7 +5,7 @@
 import re
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime,date
 from typing import Any, Callable, Generator, Iterable, MutableMapping, Optional, Tuple, Type, Union
 
 import pendulum
@@ -234,13 +234,10 @@ def chunk_date_range(
     start_date = start_date.subtract(days=conversion_window)
     slice_start = start_date
 
-    while slice_start <= end_date:
-        slice_end = min(end_date, slice_start + slice_duration)
-        yield {
-            "start_date": slice_start.format(time_format),
-            "end_date": slice_end.format(time_format),
-        }
-        slice_start = slice_end + slice_step
+    return [{
+        "start_date": slice_start.format(time_format),
+        "end_date": today.format(time_format),
+    }]
 
 
 @dataclass(repr=False, eq=False, frozen=True)


### PR DESCRIPTION


<!--
Thanks for your contribution! 
Before you submit the pull request, 
I'd like to kindly remind you to take a moment and read through our guidelines
to ensure that your contribution aligns with the type of contributions our project accepts.
All the information you need can be found here:
   https://docs.airbyte.com/contributing-to-airbyte/

We truly appreciate your interest in contributing to Airbyte,
and we're excited to see what you have to offer! 

If you have any questions or need any assistance, feel free to reach out in #contributions Slack channel.
-->

## What
*Describe what the change is solving*
*It helps to add screenshots if it affects the frontend.*

## How
*Describe the solution*

## Recommended reading order
1. `x.java`
2. `y.python`

## 🚨 User Impact 🚨
*Are there any breaking changes? What is the end result perceived by the user?*

*For connector PRs, use this section to explain which type of semantic versioning bump occurs as a result of the changes. Refer to our [Semantic Versioning for Connectors](https://docs.airbyte.com/contributing-to-airbyte/#semantic-versioning-for-connectors) guidelines for more information. **Breaking changes to connectors must be documented by an Airbyte engineer (PR author, or reviewer for community PRs) by using the [Breaking Change Release Playbook](https://docs.google.com/document/d/1VYQggHbL_PN0dDDu7rCyzBLGRtX-R3cpwXaY8QxEgzw/edit).***

*If there are breaking changes, please merge this PR with the 🚨🚨 emoji so changelog authors can further highlight this if needed.*


## Pre-merge Actions
*Expand the relevant checklist and delete the others.*

<details><summary><strong>New Connector</strong></summary>

### Community member or Airbyter

- **Community member?** Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- Connector version is set to `0.0.1`
    - `Dockerfile` has version `0.0.1`
- Documentation updated
    - Connector's `README.md`
    - Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - `docs/integrations/<source or destination>/<name>.md` including changelog with an entry for the initial version. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
    - `docs/integrations/README.md`

### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- Unit & integration tests added


### Airbyter

If this is a community PR, the Airbyte engineer reviewing this PR is responsible for the below items.

- Create a non-forked branch based on this PR and test the below items on it
- Build is successful
- If new credentials are required for use in CI, add them to GSM. [Instructions](https://docs.airbyte.io/connector-development#using-credentials-in-ci).

</details>

<details><summary><strong>Connector Generator</strong></summary>

- Issue acceptance criteria met
- PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/resources/pull-requests-handbook)
- If adding a new generator, add it to the [list of scaffold modules being tested](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connector-templates/generator/build.gradle#L41)
- The generator test modules (all connectors with `-scaffold` in their name) have been updated with the latest scaffold by running `./gradlew :airbyte-integrations:connector-templates:generator:generateScaffolds` then checking in your changes
- Documentation which references the generator is updated as needed

</details>

<details><summary><strong>Updating the Python CDK</strong></summary>

### Airbyter

Before merging:
- Pull Request description explains what problem it is solving
- Code change is unit tested
- Build and my-py check pass
- Smoke test the change on at least one affected connector
   - On Github: Run [this workflow](https://github.com/airbytehq/airbyte/actions/workflows/connectors_tests.yml), passing `--use-local-cdk --name=source-<connector>` as options
   - Locally: `airbyte-ci connectors --use-local-cdk --name=source-<connector> test`
- PR is reviewed and approved
      
After merging:
- [Publish the CDK](https://github.com/airbytehq/airbyte/actions/workflows/publish-cdk-command-manually.yml)
   - The CDK does not follow proper semantic versioning. Choose minor if this the change has significant user impact or is a breaking change. Choose patch otherwise.
   - Write a thoughtful changelog message so we know what was updated.
- Merge the platform PR that was auto-created for updating the Connector Builder's CDK version
   - This step is optional if the change does not affect the connector builder or declarative connectors.

</details>
