### PR TITLE
Google Ads connector: add support for customer_id exclusion

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -54,7 +54,7 @@ class SourceGoogleAds(AbstractSource):
     raise_exception_on_missing_stream = False
 
     @staticmethod
-    def _validate_and_transform(config: Mapping[str, Any]):
+    def _validate_and_transform(config: dict[str, Any]):
         if config.get("end_date") == "":
             config.pop("end_date")
         for query in config.get("custom_queries_array", []):
@@ -70,6 +70,10 @@ class SourceGoogleAds(AbstractSource):
         if "customer_id" in config:
             config["customer_ids"] = config["customer_id"].split(",")
             config.pop("customer_id")
+        config["exclude_customer_ids"] = set()
+        if "exclude_customer_id" in config:
+            config["exclude_customer_ids"] = set(config["exclude_customer_id"].split(","))
+            config.pop("exclude_customer_id")
 
         return config
 
@@ -123,6 +127,8 @@ class SourceGoogleAds(AbstractSource):
         unique_customers = []
         seen_ids = set()
         for customer in customers:
+            if customer.id in config["exclude_customer_ids"]:
+                continue
             if customer.id in seen_ids:
                 continue
             seen_ids.add(customer.id)

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/source.py
@@ -70,7 +70,6 @@ class SourceGoogleAds(AbstractSource):
         if "customer_id" in config:
             config["customer_ids"] = config["customer_id"].split(",")
             config.pop("customer_id")
-        config["exclude_customer_ids"] = set()
         if "exclude_customer_id" in config:
             config["exclude_customer_ids"] = set(config["exclude_customer_id"].split(","))
             config.pop("exclude_customer_id")

--- a/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
+++ b/airbyte-integrations/connectors/source-google-ads/source_google_ads/spec.json
@@ -131,6 +131,16 @@
         "default": 14,
         "examples": [14],
         "order": 6
+      },
+      "exclude_customer_id": {
+        "title": "Excluded Customer ID(s)",
+        "type": "string",
+        "description": "Comma-separated list of (client) customer IDs to exclude. Each customer ID must be specified as a 10-digit number without dashes. For detailed instructions on finding this value, refer to our <a href=\"https://docs.airbyte.com/integrations/sources/google-ads#setup-guide\">documentation</a>.",
+        "pattern": "^[0-9]{10}(,[0-9]{10})*$",
+        "pattern_descriptor": "The customer ID must be 10 digits. Separate multiple customer IDs using commas.",
+        "examples": ["6783948572,5839201945"],
+        "default": "",
+        "order": 7
       }
     }
   },


### PR DESCRIPTION
## What
Adding support for customers exclusion to accommodate some of our accounts setup.

## How
`exclude_customer_id` key is added to the config. Any account mentioned there is later excluded from `get_customers` output.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌
